### PR TITLE
Don't sort mck->generators in Test::Kwalitee

### DIFF
--- a/lib/Test/Kwalitee.pm
+++ b/lib/Test/Kwalitee.pm
@@ -85,7 +85,7 @@ sub import
         dist    => $args{basedir},
     });
 
-    for my $generator (sort { $a cmp $b } @{ $analyzer->mck()->generators() } )
+    for my $generator ( @{ $analyzer->mck()->generators() } )
     {
         next if $generator =~ /Unpack/;
         next if $generator =~ /CPAN$/;


### PR DESCRIPTION
... as generators are already ordered (with sub order {} in Module::CPANTS::Kwalitee::*)

Some of the metrics (proper_libs etc) depend on the result of other generators/analyzers. Sorting in Test::Kwalitee may (and actually do) break this dependency. For example, no_index in (MY)META.yml will be ignored, and some of the metrics may fail because of the files that should be ignored.
