### PR TITLE
Skip tests removed from Module::CPANTS::Analyse

### DIFF
--- a/lib/Test/Kwalitee.pm
+++ b/lib/Test/Kwalitee.pm
@@ -85,6 +85,7 @@ sub import
         dist    => $args{basedir},
     });
 
+    my %done;
     for my $generator (sort { $a cmp $b } @{ $analyzer->mck()->generators() } )
     {
         next if $generator =~ /Unpack/;
@@ -100,6 +101,11 @@ sub import
             next unless $sub;
             $sub->( $analyzer->d(), $indicator );
         }
+    }
+
+    for my $name (sort keys %run_tests) {
+        next if $done{ $name };
+        $Test->skip("$name is removed");
     }
 }
 


### PR DESCRIPTION
Some of the metrics will be removed (or moved to Module::CPANTS::SiteKwalitee) in the near future when the next version of Module::CPANTS::Analyse is released. This patch checks which tests are done and skips the rest in the end.

Or, you might want to declare the number of tests that actually remain in Module::CPANTS::Analyse/Kwalitee. Whichever is ok, as long as the number of the tests is correctly handled.
