### PR TITLE
Attempt to be less clever checking for known metrics.

### DIFF
--- a/t/01-kwalitee.t
+++ b/t/01-kwalitee.t
@@ -25,6 +25,8 @@ my ($premature, @results) = run_tests(
         Test::Kwalitee->import;
     },
 );
+my @found_metrics = map { $_->{name} } @results;
+note(explain \@found_metrics );
 # this list reflects Module::CPANTS::Analyse 0.87
 my (@metrics) = qw(
     has_buildtool


### PR DESCRIPTION
The existing code used Test::Deep, and the real purpose of what it was
doing was a bit vauge, not to mention, when it did fail, the message
given was pretty muddy.

This gives slightly more detailed results when things do go bad, and
removes the need for Test::Deep.

Also, I codified the exact behaviour Test::Deep was performing, namely,
it had to check every key of the metric data.

But I get the impression this was not trying to test that, but was
simply trying to test a list of named metrics _EXISTED_, and the need to
detail all the other properties of every metric was just an
implementation detail required to work with Test::Deep
